### PR TITLE
Support msr quality indicator 'M'

### DIFF
--- a/msrecord.c
+++ b/msrecord.c
@@ -243,7 +243,8 @@ sl_msr_parse_size (SLlog *log, const char *msrecord, SLMSrecord **ppmsr,
   /* Sanity check for msr/quality indicator */
   if (msr->fsdh.dhq_indicator != 'D' &&
       msr->fsdh.dhq_indicator != 'R' &&
-      msr->fsdh.dhq_indicator != 'Q')
+      msr->fsdh.dhq_indicator != 'Q' &&
+      msr->fsdh.dhq_indicator != 'M')
   {
     sl_log_rl (log, 2, 0, "record header/quality indicator unrecognized: %c\n",
                msr->fsdh.dhq_indicator);


### PR DESCRIPTION
Noticed libslink was up on github now, so I figured I'd send this through again. (It's just iris-edu/slinktool#4, but in the right repo this time.)