### PR TITLE
Define LIBSLINK_VERSION_MAJOR in libslink.h to help SeedLink clients handle API changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,10 @@
 #   LDFLAGS : Specify linker options to use
 #   CPPFLAGS : Specify c-preprocessor options to use
 
-# Extract version from libslink.h, expected line should include LIBSLINK_VERSION "#.#.#"
-MAJOR_VER = $(shell grep LIBSLINK_VERSION libslink.h | grep -Eo '[0-9]+.[0-9]+.[0-9]+' | cut -d . -f 1)
-FULL_VER = $(shell grep LIBSLINK_VERSION libslink.h | grep -Eo '[0-9]+.[0-9]+.[0-9]+')
+# Extract version from libslink.h
+MAJOR_VER = $(shell grep -E 'LIBSLINK_VERSION_MAJOR[ \t]+[0-9]+' libslink.h | grep -Eo '[0-9]+')
+MINOR_VER = $(shell grep -E 'LIBSLINK_VERSION_MINOR[ \t]+[0-9]+' libslink.h | grep -Eo '[0-9]+')
+PATCH_VER = $(shell grep -E 'LIBSLINK_VERSION_PATCH[ \t]+[0-9]+' libslink.h | grep -Eo '[0-9]+')
 COMPAT_VER = $(MAJOR_VER).0.0
 
 # Default settings for install target
@@ -37,12 +38,12 @@ OS := $(shell uname -s)
 ifeq ($(OS), Darwin)
 	LIB_SO_BASE = $(LIB_NAME).dylib
 	LIB_SO_MAJOR = $(LIB_NAME).$(MAJOR_VER).dylib
-	LIB_SO = $(LIB_NAME).$(FULL_VER).dylib
-	LIB_OPTS = -dynamiclib -compatibility_version $(COMPAT_VER) -current_version $(FULL_VER) -install_name $(LIB_SO)
+	LIB_SO = $(LIB_NAME).$(MAJOR_VER).$(MINOR_VER).$(PATCH_VER).dylib
+	LIB_OPTS = -dynamiclib -compatibility_version $(COMPAT_VER) -current_version $(MAJOR_VER).$(MINOR_VER).$(PATCH_VER) -install_name $(LIB_SO)
 else
 	LIB_SO_BASE = $(LIB_NAME).so
 	LIB_SO_MAJOR = $(LIB_NAME).so.$(MAJOR_VER)
-	LIB_SO = $(LIB_NAME).so.$(FULL_VER)
+	LIB_SO = $(LIB_NAME).so.$(MAJOR_VER).$(MINOR_VER).$(PATCH_VER)
 	LIB_OPTS = -shared -Wl,--version-script=libslink.map -Wl,-soname,$(LIB_SO_MAJOR)
 endif
 
@@ -83,7 +84,7 @@ install: shared
 	     -e 's|@EXEC_PREFIX@|$(EXEC_PREFIX)|g' \
 	     -e 's|@LIBDIR@|$(LIBDIR)|g' \
 	     -e 's|@INCLUDEDIR@|$(PREFIX)/include|g' \
-	     -e 's|@VERSION@|$(FULL_VER)|g' \
+	     -e 's|@VERSION@|$(MAJOR_VER).$(MINOR_VER).$(PATCH_VER)|g' \
 	     slink.pc.in > $(DESTDIR)$(LIBDIR)/pkgconfig/slink.pc
 	@mkdir -p $(DESTDIR)$(DOCDIR)/example
 	@cp -r example $(DESTDIR)$(DOCDIR)/

--- a/libslink.h
+++ b/libslink.h
@@ -28,7 +28,14 @@
 extern "C" {
 #endif
 
-#define LIBSLINK_VERSION "3.0.0DEV"    /**< libslink version */
+#define LIBSLINK_VERSION_MAJOR  3      /**< libslink major version */
+#define LIBSLINK_VERSION_MINOR  0      /**< libslink minor version */
+#define LIBSLINK_VERSION_PATCH  0
+#define LIBSLINK_STRINGIFY(a)   LIBSLINK_XSTRINGIFY(a)
+#define LIBSLINK_XSTRINGIFY(a)  #a
+#define LIBSLINK_VERSION        LIBSLINK_STRINGIFY(LIBSLINK_VERSION_MAJOR) "." \
+                                LIBSLINK_STRINGIFY(LIBSLINK_VERSION_MINOR) "." \
+                                LIBSLINK_STRINGIFY(LIBSLINK_VERSION_PATCH) "DEV"
 #define LIBSLINK_RELEASE "2021.191"    /**< libslink release date */
 
 /** @defgroup seedlink-connection SeedLink Connection */


### PR DESCRIPTION
Good morning @chad-iris,

I noticed that you are working towards libslink v3.0.0, which has a slightly different [API](https://en.wikipedia.org/wiki/Application_Programming_Interface) compared to libslink v2.x.

This pull request splits `LIBSLINK_VERSION` in libslink.h into its three constituent parts, i.e. `LIBSLINK_VERSION_MAJOR` and `LIBSLINK_VERSION_MINOR` and `LIBSLINK_VERSION_PATCH`.

`LIBSLINK_VERSION_MAJOR` provides SeedLink clients with the _most-obvious_ method of selecting which [API](https://en.wikipedia.org/wiki/Application_Programming_Interface) to target, for example:

```c
#if LIBSLINK_VERSION_MAJOR >= 3
  /* the sl_recvdata() function returns int64_t */
  const int64_t ret = sl_recvdata (slconn, buffer, maxbytes, ident);
#else
  /* LIBSLINK_VERSION_MAJOR evaluates to 0 if LIBSLINK_VERSION_MAJOR is undefined */
  /* the sl_recvdata() function returns int */
  const int ret = sl_recvdata (slconn, buffer, maxbytes, ident);
#endif
```

Without this pull request, many SeedLink clients will have to resort to ugly hacks to select which [API](https://en.wikipedia.org/wiki/Application_Programming_Interface) to target.  Friendly reminder that some SeedLink clients have to be built against the platform-provided libslink v2.6, even though these SeedLink clients can _also_ be built against libslink v3.0.0.

Will you please **accept** this pull request, **before** you release libslink v3.0.0?

Thank you very much for your efforts!